### PR TITLE
Change default branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,18 @@
 name: Test
 on:
   pull_request:
+    branches:
+      - main
   push:
     branches:
-      - master
+      - main
       - 'releases/*'
 
 jobs:
   test:
     strategy:
       matrix:
-        runs-on: [ubuntu-22.04, ubuntu-20.04]
+        runs-on: [ubuntu-24.04, ubuntu-22.04]
     runs-on: ${{ matrix.runs-on }}
     services:
       svn:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The process executes rsync from Git working tree to SubVersion working tree with
 
 ### default behavior
 
-rsync will read [default .rsync-filter file](https://github.com/yukihiko-shinoda/dockerfile-deploy-wordpress-plugin/blob/master/runner/project/roles/rsync_git_to_svn/templates/.rsync-filter.j2).
+rsync will read [default .rsync-filter file](https://github.com/yukihiko-shinoda/dockerfile-deploy-wordpress-plugin/blob/main/runner/project/roles/rsync_git_to_svn/templates/.rsync-filter.j2).
 
 ### customizing behavior
 


### PR DESCRIPTION
This pull request updates CI/CD and dependency management configurations to align with current best practices and branch naming conventions. The most important changes are:

**CI/CD Workflow Updates:**

* The GitHub Actions workflow in `.github/workflows/test.yml` now targets the `main` branch instead of `master` and adds support for Ubuntu 24.04 in the test matrix.

**Dependency Management:**

* A new `.github/dependabot.yml` file is added to enable weekly automated updates for Docker and GitHub Actions dependencies.

**Documentation:**

* The `README.md` is updated to reference the `main` branch instead of `master` in a documentation link, reflecting the repository's branch renaming.