### PR TITLE
Upgrade base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM futureys/deploy-wordpress-plugin:2.1.1
+FROM futureys/deploy-wordpress-plugin:2.3.0
 RUN mv /bin/entrypoint /bin/entrypoint-deploy-wordpress-plugin
 COPY entrypoint.sh /bin/entrypoint
 RUN chmod +x /bin/entrypoint


### PR DESCRIPTION
This pull request updates the base image version in the `Dockerfile` to ensure the project uses the latest features and security updates.

- Dependency update:
  * Upgraded the base image from `futureys/deploy-wordpress-plugin:2.1.1` to `futureys/deploy-wordpress-plugin:2.3.0` in the `Dockerfile`.